### PR TITLE
[Feat] 마이페이지 지원 정보 조회 기능 구현 및 모집 종료 기준 추가

### DIFF
--- a/src/modules/user/dto/application-status.dto.ts
+++ b/src/modules/user/dto/application-status.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApplicationStatusDto {
+  @ApiProperty({
+    description: '프로젝트 제목',
+    example: '클론코딩 사이드 프로젝트 팀원 모집',
+  })
+  projectTitle: string;
+
+  @ApiProperty({
+    description: '지원 상태 (WAITING/ACCEPTED/REJECTED)',
+    example: 'ACCEPTED',
+  })
+  status: string;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -172,7 +172,7 @@ export class UserController {
     }
   }
 
-  @Get('my-page/applications')
+  @Get('me/applications')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: '마이페이지 지원 정보 조회',

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -176,7 +176,8 @@ export class UserController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: '마이 페이지 지원 정보 조회',
-    description: '사용자가 지원한 프로젝트 목록과 합격 여부를 반환합니다.',
+    description: `사용자가 지원한 프로젝트 목록과 합격 여부를 반환합니다.<br>
+                  지원은 했으나 불합 처리 되지 않았어도, 모집 종료시 불합격입니다. 따라서 불/합 리스트만 보입니다.`,
   })
   @ApiResponse({
     status: 200,
@@ -190,10 +191,6 @@ export class UserController {
         {
           projectTitle: "클론코딩 모집",
           status: "REJECTED"
-        },
-        {
-          projectTitle: "클론코딩 사이드 프로젝트 모집 공고",
-          status: "WAITING"
         }
       ]
     },

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -175,13 +175,13 @@ export class UserController {
   @Get('my-page/applications')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: '마이 페이지 지원 정보 조회',
+    summary: '마이페이지 지원 정보 조회',
     description: `사용자가 지원한 프로젝트 목록과 합격 여부를 반환합니다.<br>
                   지원은 했으나 불합 처리 되지 않았어도, 모집 종료시 불합격입니다. 따라서 불/합 리스트만 보입니다.`,
   })
   @ApiResponse({
     status: 200,
-    description: '사용자의 지원한 프로젝트와 상태를 성공적으로 반환',
+    description: '사용자의 지원한 프로젝트와 합격, 불합격에 따른 상태 반환',
     schema: {
       example: [
         {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -2,6 +2,7 @@ import { Injectable, BadRequestException, InternalServerErrorException } from '@
 import { PrismaService } from '../prisma/prisma.service';
 import * as bcrypt from 'bcrypt';
 import { UploadService } from '../upload/upload.service';
+import { ApplicationStatusDto } from './dto/application-status.dto';
 
 @Injectable()
 export class UserService {
@@ -73,21 +74,48 @@ export class UserService {
     }
   }
 
-  async getApplicationsByUserId(userId: number) {
+  async getApplicationsByUserId(userId: number): Promise<ApplicationStatusDto[]> {
     try {
       const applications = await this.prisma.applicant.findMany({
         where: { userId },
         include: {
           Project: {
-            select: { title: true },
+            select: {
+              title: true,
+              recruitmentEndDate: true, // 모집 종료 날짜를 가져옴
+            },
           },
         },
       });
   
-      return applications.map((application) => ({
-        projectTitle: application.Project?.title || '프로젝트 없음',
-        status: application.status,
-      }));
+      // 모집 종료 여부를 기준으로 상태를 필터링
+      const currentDate = new Date();
+  
+      return applications
+        .map((application) => {
+          const isRecruitmentEnded = application.Project?.recruitmentEndDate
+            ? new Date(application.Project.recruitmentEndDate) < currentDate
+            : false;
+  
+          // 모집 종료 시 불합격 처리
+          if (isRecruitmentEnded && application.status !== 'ACCEPTED') {
+            return {
+              projectTitle: application.Project?.title || '프로젝트 없음',
+              status: 'REJECTED',
+            };
+          }
+  
+          // 합격 상태 또는 이미 불합격인 경우만 반환
+          if (application.status === 'ACCEPTED' || application.status === 'REJECTED') {
+            return {
+              projectTitle: application.Project?.title || '프로젝트 없음',
+              status: application.status,
+            };
+          }
+  
+          return null; // WAITING 상태는 표시하지 않음
+        })
+        .filter((item) => item !== null); // null 값 제거
     } catch (error) {
       console.error('Error while fetching applications:', error);
       throw new InternalServerErrorException('지원한 프로젝트를 불러오는 중 오류가 발생했습니다.');

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -72,4 +72,25 @@ export class UserService {
       throw new InternalServerErrorException('프로필 이미지 업데이트 중 오류가 발생했습니다.');
     }
   }
+
+  async getApplicationsByUserId(userId: number) {
+    try {
+      const applications = await this.prisma.applicant.findMany({
+        where: { userId },
+        include: {
+          Project: {
+            select: { title: true },
+          },
+        },
+      });
+  
+      return applications.map((application) => ({
+        projectTitle: application.Project?.title || '프로젝트 없음',
+        status: application.status,
+      }));
+    } catch (error) {
+      console.error('Error while fetching applications:', error);
+      throw new InternalServerErrorException('지원한 프로젝트를 불러오는 중 오류가 발생했습니다.');
+    }
+  }
 }


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 마이페이지 지원 정보 조회 기능 구현:
    - 모집 종료 여부를 기준으로 불합격 상태 자동 처리
    - `ACCEPTED`와 `REJECTED` 상태만 반환(`WAITING` 제외)
  - [x] DTO 생성 및 적용:
    - `ApplicationStatusDto`를 활용해 데이터 반환 형식 정의
  - [x] 컨트롤러와 서비스 로직 업데이트:
    - `CurrentUser` 데코레이터로 사용자 ID 간결히 가져오기
    - `GET /user/my-page/applications` API 로직 및 문서화 추가

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->
- [ ] 모집 종료 처리 로직 개선:
  - 현재는 모집 종료 여부를 `Project.recruitmentEndDate`와 비교하여 불합격 처리. 
  이 방식을 더 최적화할 방법이 있을까요!?


---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **마이페이지 지원 정보 조회(WAITING 제외 출력)**                 | 
|-----------------------------|
| ![image](https://github.com/user-attachments/assets/88fa6a95-fa7f-4289-b326-20647026bf22)   | 
---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
추가 수정 필요시 수정 하겠습니다!

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->

- **테스트 방법**:
  1. `GET /user/me/applications` 호출.
  2. JWT 토큰 포함 여부에 따른 결과 확인.
  3. 모집 종료 날짜와 상태 변화 테스트.

