### PR TITLE
[Feat] 내 정보 보기 및 다른 유저 정보 보기 기능 구현 및 프리즈마 구조 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,8 +13,8 @@ model Applicant {
   userId      Int?
   projectId   Int?
   message     String?           @db.Text
-  email       String?           @db.VarChar(255) // 최대 255자로 설정
-  phoneNumber String?           @db.VarChar(15)  // 최대 15자로 설정 (국제 전화번호 기준)
+  email       String?           @db.VarChar(255)
+  phoneNumber String?           @db.VarChar(15)
   career      String?           @db.Text
   status      Applicant_status? @default(WAITING)
   createdAt   DateTime?         @default(now()) @db.Timestamp(0)
@@ -58,6 +58,7 @@ model PositionTag {
   name               String               @unique(map: "name") @db.VarChar(255)
   createdAt          DateTime?            @default(now()) @db.Timestamp(0)
   ProjectPositionTag ProjectPositionTag[]
+  User               User[]
 }
 
 model Project {
@@ -72,8 +73,8 @@ model Project {
   views                Int                  @default(0)
   isBeginner           Boolean              @default(false)
   isDone               Boolean              @default(false)
-  recruitmentEndDate   DateTime             @db.Date
   recruitmentStartDate DateTime             @db.Date
+  recruitmentEndDate   DateTime             @db.Date
   createdAt            DateTime             @default(now()) @db.Timestamp(0)
   updatedAt            DateTime             @default(now()) @db.Timestamp(0)
   Applicant            Applicant[]
@@ -106,23 +107,26 @@ model SkillTag {
 }
 
 model User {
-  id           Int            @id @default(autoincrement())
-  nickname     String         @unique(map: "nickname") @db.VarChar(255)
-  email        String         @unique(map: "email") @db.VarChar(255)
-  password     String         @db.VarChar(255)
-  bio          String?        @db.Text
-  profileImg   String?        @db.Text
-  github       String?        @db.VarChar(255)  // GitHub URL 추가
-  position     String?        @db.VarChar(100)  // 포지션 추가
-  career       String?        @db.Text          // 경력 추가
-  userLevel    UserLevel?     @default(Beginner) // 유저별 등급 추가
-  createdAt    DateTime?      @default(now()) @db.Timestamp(0)
-  updatedAt    DateTime?      @default(now()) @db.Timestamp(0)
-  Applicant    Applicant[]
-  Notification Notification[]
-  Project      Project[]
-  sessions     Session[]
-  UserSkillTag UserSkillTag[]
+  id            Int            @id @default(autoincrement())
+  nickname      String         @unique(map: "nickname") @db.VarChar(255)
+  email         String         @unique(map: "email") @db.VarChar(255)
+  password      String         @db.VarChar(255)
+  bio           String?        @db.Text
+  profileImg    String?        @db.Text
+  userLevel     UserLevel?     @default(Beginner)
+  github        String?        @db.VarChar(255)
+  career        String?        @db.Text
+  createdAt     DateTime?      @default(now()) @db.Timestamp(0)
+  updatedAt     DateTime?      @default(now()) @db.Timestamp(0)
+  positionTagId Int?
+  Applicant     Applicant[]
+  Notification  Notification[]
+  Project       Project[]
+  sessions      Session?
+  positionTag   PositionTag?   @relation(fields: [positionTagId], references: [id])
+  UserSkillTag  UserSkillTag[]
+
+  @@index([positionTagId], map: "User_positionTagId_fkey")
 }
 
 model UserSkillTag {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,9 @@ model User {
   password     String         @db.VarChar(255)
   bio          String?        @db.Text
   profileImg   String?        @db.Text
+  github       String?        @db.VarChar(255)  // GitHub URL 추가
+  position     String?        @db.VarChar(100)  // 포지션 추가
+  career       String?        @db.Text          // 경력 추가
   userLevel    UserLevel?     @default(Beginner) // 유저별 등급 추가
   createdAt    DateTime?      @default(now()) @db.Timestamp(0)
   updatedAt    DateTime?      @default(now()) @db.Timestamp(0)

--- a/src/modules/user/dto/my-info-response.dto.ts
+++ b/src/modules/user/dto/my-info-response.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class SkillDto {
+  @ApiProperty({ description: '스킬 이름', example: 'JavaScript' })
+  skillName: string;
+
+  @ApiProperty({ description: '스킬 이미지 URL', example: 'https://example.com/js-logo.png' })
+  skillImg: string;
+}
+
+export class MyInfoResponseDto {
+  @ApiProperty({ description: '사용자 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '사용자 닉네임', example: 'Jenny' })
+  nickname: string;
+
+  @ApiProperty({ description: '사용자 이메일', example: 'jenny@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '사용자 소개 (bio)', example: '안녕하세요, 저는 프론트엔드 개발자입니다.' })
+  bio: string;
+
+  @ApiProperty({ description: '사용자 프로필 이미지 URL', example: 'https://example.com/profile.jpg' })
+  profileImg: string;
+
+  @ApiProperty({ description: '사용자 레벨', example: 'Beginner' })
+  userLevel: string;
+
+  @ApiProperty({ description: 'GitHub 링크', example: 'https://github.com/jennywithlove' })
+  github: string;
+
+  @ApiProperty({ description: '사용자 포지션', example: '프론트엔드 개발자' })
+  position: string;
+
+  @ApiProperty({ description: '사용자 경력', example: '2020.12.10 ~ 2022.02.04 OO기업 인턴' })
+  career: string;
+
+  @ApiProperty({
+    description: '사용자의 스킬셋',
+    type: [SkillDto],
+    example: [
+      { skillName: 'JavaScript', skillImg: 'https://example.com/js-logo.png' },
+      { skillName: 'React', skillImg: 'https://example.com/react-logo.png' },
+    ],
+  })
+  skills: SkillDto[];
+
+  @ApiProperty({ description: '사용자 생성일', example: '2023-01-01T00:00:00.000Z' })
+  createdAt: Date;
+}

--- a/src/modules/user/dto/my-info-response.dto.ts
+++ b/src/modules/user/dto/my-info-response.dto.ts
@@ -8,6 +8,14 @@ class SkillDto {
   skillImg: string;
 }
 
+class PositionDto {
+  @ApiProperty({ description: '포지션 ID', example: 2 })
+  id: number;
+
+  @ApiProperty({ description: '포지션 이름', example: '프론트엔드' })
+  name: string;
+}
+
 export class MyInfoResponseDto {
   @ApiProperty({ description: '사용자 ID', example: 1 })
   id: number;
@@ -30,11 +38,15 @@ export class MyInfoResponseDto {
   @ApiProperty({ description: 'GitHub 링크', example: 'https://github.com/jennywithlove' })
   github: string;
 
-  @ApiProperty({ description: '사용자 포지션', example: '프론트엔드 개발자' })
-  position: string;
-
   @ApiProperty({ description: '사용자 경력', example: '2020.12.10 ~ 2022.02.04 OO기업 인턴' })
   career: string;
+
+  @ApiProperty({
+    description: '포지션 태그 정보',
+    type: PositionDto,
+    example: { id: 2, name: '프론트엔드' },
+  })
+  positionTag: PositionDto;
 
   @ApiProperty({
     description: '사용자의 스킬셋',

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -9,6 +9,7 @@ import {
   UseInterceptors,
   UploadedFile,
   Get,
+  Param,
   UseGuards,
   InternalServerErrorException 
  } from '@nestjs/common';
@@ -19,6 +20,7 @@ import { CurrentUser } from '../../decorators/curretUser.decorator';
 import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { CheckNicknameDto } from './dto/check-nickname.dto';
 import { ApplicationStatusDto } from './dto/application-status.dto';
+import { MyInfoResponseDto } from './dto/my-info-response.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -218,5 +220,82 @@ export class UserController {
     return applications;
   }
 
+    // 내 정보 조회
+  @Get('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '내 정보 보기',
+    description: '인증된 사용자의 정보를 반환하며, 포지션, 깃허브 링크, 경력, 스킬셋 등을 포함합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자의 정보 반환',
+    type: MyInfoResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않거나 만료된 토큰입니다.',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자 정보가 존재하지 않을 경우',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자 정보를 찾을 수 없습니다.',
+        error: 'Not Found',
+      },
+    },
+  })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
+  async getMyInfo(@CurrentUser() userId: number): Promise<MyInfoResponseDto> {
+    return this.userService.getUserInfoWithSkills(userId);
+  }
+  
+  // 다른 사용자 정보 조회
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '다른 사용자 정보 보기',
+    description: '특정 사용자의 정보를 반환합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자의 정보 반환',
+    type: MyInfoResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 - 사용자 ID 형식이 잘못되었거나 누락됨',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '잘못된 사용자 ID입니다.',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자 정보가 존재하지 않을 경우',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자 정보를 찾을 수 없습니다.',
+        error: 'Not Found',
+      },
+    },
+  })
+  async getOtherUserInfo(@Param('id') id: number): Promise<MyInfoResponseDto> {
+    return this.userService.getUserInfoWithSkills(id);
+  }
 
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -294,6 +294,8 @@ export class UserController {
       },
     },
   })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
   async getOtherUserInfo(@Param('id') id: number): Promise<MyInfoResponseDto> {
     return this.userService.getUserInfoWithSkills(id);
   }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -124,9 +124,9 @@ export class UserService {
 
   async getUserInfoWithSkills(userId: number) {
     if (!userId || typeof userId !== 'number') {
-      throw new BadRequestException('잘못된 사용자 ID입니다.');
+      return null; // 사용자 ID가 잘못된 경우 null 반환
     }
-    // 사용자 기본 정보 가져오기
+  
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -137,17 +137,21 @@ export class UserService {
         profileImg: true,
         userLevel: true,
         github: true,
-        position: true,
         career: true,
+        positionTag: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
         createdAt: true,
       },
     });
-
+  
     if (!user) {
-      throw new BadRequestException('사용자 정보를 찾을 수 없습니다.');
+      return null; // 사용자 정보가 없는 경우 null 반환
     }
-
-    // 사용자 스킬셋 가져오기
+  
     const userSkills = await this.prisma.userSkillTag.findMany({
       where: { userId },
       include: {
@@ -159,15 +163,24 @@ export class UserService {
         },
       },
     });
-
+  
     const skills = userSkills.map((userSkill) => ({
       skillName: userSkill.SkillTag.name,
       skillImg: userSkill.SkillTag.img,
     }));
-
+  
     return {
-      ...user,
+      id: user.id,
+      nickname: user.nickname,
+      email: user.email,
+      bio: user.bio,
+      profileImg: user.profileImg,
+      userLevel: user.userLevel,
+      github: user.github,
+      career: user.career,
+      positionTag: user.positionTag,
       skills,
+      createdAt: user.createdAt,
     };
   }
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -121,4 +121,54 @@ export class UserService {
       throw new InternalServerErrorException('지원한 프로젝트를 불러오는 중 오류가 발생했습니다.');
     }
   }
+
+  async getUserInfoWithSkills(userId: number) {
+    if (!userId || typeof userId !== 'number') {
+      throw new BadRequestException('잘못된 사용자 ID입니다.');
+    }
+    // 사용자 기본 정보 가져오기
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        nickname: true,
+        email: true,
+        bio: true,
+        profileImg: true,
+        userLevel: true,
+        github: true,
+        position: true,
+        career: true,
+        createdAt: true,
+      },
+    });
+
+    if (!user) {
+      throw new BadRequestException('사용자 정보를 찾을 수 없습니다.');
+    }
+
+    // 사용자 스킬셋 가져오기
+    const userSkills = await this.prisma.userSkillTag.findMany({
+      where: { userId },
+      include: {
+        SkillTag: {
+          select: {
+            name: true,
+            img: true,
+          },
+        },
+      },
+    });
+
+    const skills = userSkills.map((userSkill) => ({
+      skillName: userSkill.SkillTag.name,
+      skillImg: userSkill.SkillTag.img,
+    }));
+
+    return {
+      ...user,
+      skills,
+    };
+  }
+
 }


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 내 정보 보기 API 구현 (`GET /user/me`)
  - [x] 다른 유저 정보 보기 API 구현 (`GET /user/:id`)
  - [x] JWT 인증을 통한 접근 제한 추가
  - [x] 프리즈마 구조 수정: 
  피그마의 마이페이지1, 유저조회 페이지1과 같이 User 테이블에 GitHub, Position, Career 필드 추가

---

### 🚀 수정된 구현한 내용 (What was implemented)

- ✨ 주요 기능:
  - [x] **프리즈마 User 테이블의 position을 positionTagId로 변경 및 PositionTag 테이블과 연동**
    - 기존 `User` 모델의 `position` 필드를 `positionTagId`로 변경하고, `PositionTag` 테이블과 관계를 설정.
    - 포지션 정보를 조회할 때 `PositionTag` 테이블에서 가져오도록 수정.
  - [x] **내 정보 보기, 다른 유저 정보 보기 컨트롤러 에러처리 수정**
    - 에러처리를 서비스에서 컨트롤러로 이동하여, 요청별로 적절한 에러 메시지와 상태 코드 반환.
    - `401 Unauthorized`와 `400 Bad Request`, `404 Not Found` 등 구체적인 에러를 컨트롤러에서 관리.
  - [x] **사용자 정보 조회 로직 수정**
    - 사용자 조회 실패 시 `null`을 반환하도록 수정.
    - 컨트롤러에서 `null`을 확인하여 에러를 처리하며, 포지션 태그 정보도 함께 반환.
  - [x] **사용자 정보 조회 DTO에 포지션 태그 DTO 추가**
    - `PositionTagDto`를 `MyInfoResponseDto`에 포함하여 사용자 응답에 포지션 태그 정보를 명확히 포함.
    - DTO 변경 사항 반영하여 서비스 및 컨트롤러 로직 수정.

---

# 🤔 논의가 필요한 사항 (Points to discuss)

<!-- 논의가 필요한 사항, 개선해야 할 부분을 작성해주세요. -->

피그마의 마이페이지1, 유저조회 페이지1에서 스킬셋, 포지션, 깃허브, 경력을 출력해야해서
DB에서 관리하는 게 낫겠다고 생각이 들어서 GitHub, Position, Career 들을 추가했습니다!
필요없다면 수정 고려해보겠습니다! 

---

### 🤔 수정하면서 추가된 논의가 필요한 사항 (Points to discuss)

- [ ] `PositionTag`를 연동한 방식이 프로젝트 구조와 맞는지 검토 필요.

---


# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
| **내 정보 보기**            | **다른 유저 정보 보기**     |
|-----------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/211edc0b-7c7d-44f6-804c-e0e1ce819130)      | ![image](https://github.com/user-attachments/assets/e446afab-7ebc-4012-8b08-430b06bde253) |

---

### 🖼️ 수정된 결과 이미지 (Screenshots)

| **내 정보 보기**                   | **다른 유저 정보 보기**                    |
|------------------------------|------------------------------|
| ![image](https://github.com/user-attachments/assets/e4910b04-f201-4453-8478-2d56e4ae26f2)          | ![image](https://github.com/user-attachments/assets/5be18581-206d-4364-8e13-77ae443d4b41)              |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->
필요시 수정하겠습니다!

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->

프리즈마 pull해서 작업해주세용!
- **테스트 방법**:
  1. `GET /user/me` 호출 시 JWT 토큰 포함하여 요청
  2. `GET /user/:id` 호출 시 JWT 토큰 포함, 유효한 ID 사용하여 요청

