### PR TITLE
[Fix] 인증코드 조회 에러처리 수정

### DIFF
--- a/src/modules/authenticode/authenticode.service.ts
+++ b/src/modules/authenticode/authenticode.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
+import { Injectable, BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
 import * as crypto from 'crypto';
@@ -58,11 +58,17 @@ export class AuthenticodeService {
   
     // 인증 코드 유효성 검증
     if (!authRecord) {
-      throw new BadRequestException('유효하지 않은 인증 코드입니다.');
+      throw new HttpException(
+        { message: '유효하지 않은 인증 코드입니다.' },
+        HttpStatus.BAD_REQUEST, // 400 상태 코드
+      );
     }
   
     if (authRecord.expiresAt < new Date()) {
-      throw new BadRequestException('인증 코드가 만료되었습니다.');
+      throw new HttpException(
+        { message: '인증 코드가 만료되었습니다.' },
+        HttpStatus.UNAUTHORIZED, // 401 상태 코드
+      );
     }
   
     // 인증 코드 상태를 사용 완료로 업데이트
@@ -74,7 +80,3 @@ export class AuthenticodeService {
     return { message: '인증 코드가 확인되었습니다.' };
   }
 }
-
-
-  
-


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 인증코드 확인시 status code api 문서에서는 401일때 만료, 400일때 유효하지 않은 코드가 나오도록 안내되어있음.
  하지만 코드 만료시 status code와 유효하지 않은 코드시 status code가 둘 다 400으로 출력되어 에러처리 수정완료.


---