### PR TITLE
 내 정보 수정 추가 내 정보 보기 API 개선 - career JSON 파싱 수정

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { JwtAuthGuard } from './guard/jwt-auth.guard';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthenticodeModule } from '../authenticode/authenticode.module';
 import { UploadModule } from '../upload/upload.module';
+import { SkillTagModule } from '../skill-tag/skill-tag.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { UploadModule } from '../upload/upload.module';
     }),
     AuthenticodeModule,
     UploadModule,
+    SkillTagModule,
   ],
   controllers: [AuthController],
   providers: [

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { AuthenticodeModule } from '../authenticode/authenticode.module';
 import { UploadModule } from '../upload/upload.module';
 import { PositionTagModule } from '../position-tag/position-tag.module';
+import { SkillTagModule } from '../skill-tag/skill-tag.module'; 
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { PositionTagModule } from '../position-tag/position-tag.module';
     AuthenticodeModule,
     UploadModule,
     PositionTagModule,
+    SkillTagModule
   ],
   controllers: [AuthController],
   providers: [

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -9,7 +9,7 @@ import { JwtAuthGuard } from './guard/jwt-auth.guard';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthenticodeModule } from '../authenticode/authenticode.module';
 import { UploadModule } from '../upload/upload.module';
-import { SkillTagModule } from '../skill-tag/skill-tag.module';
+import { PositionTagModule } from '../position-tag/position-tag.module';
 
 @Module({
   imports: [
@@ -20,7 +20,7 @@ import { SkillTagModule } from '../skill-tag/skill-tag.module';
     }),
     AuthenticodeModule,
     UploadModule,
-    SkillTagModule,
+    PositionTagModule,
   ],
   controllers: [AuthController],
   providers: [

--- a/src/modules/skill-tag/skill-tag.service.ts
+++ b/src/modules/skill-tag/skill-tag.service.ts
@@ -19,4 +19,15 @@ export class SkillTagService {
 
     return skillTag;
   }
+
+  async fetchPositionTag({ id }: { id: number }) {
+    const positionTag = await this.prismaService.positionTag.findUnique({
+      where: { id },
+    });
+    if (!positionTag) {
+      throw new NotFoundException('해당 포지션 태그가 존재하지 않습니다.');
+    }
+
+    return positionTag;
+  }
 }

--- a/src/modules/skill-tag/skill-tag.service.ts
+++ b/src/modules/skill-tag/skill-tag.service.ts
@@ -19,15 +19,4 @@ export class SkillTagService {
 
     return skillTag;
   }
-
-  async fetchPositionTag({ id }: { id: number }) {
-    const positionTag = await this.prismaService.positionTag.findUnique({
-      where: { id },
-    });
-    if (!positionTag) {
-      throw new NotFoundException('해당 포지션 태그가 존재하지 않습니다.');
-    }
-
-    return positionTag;
-  }
 }

--- a/src/modules/user/dto/my-info-response.dto.ts
+++ b/src/modules/user/dto/my-info-response.dto.ts
@@ -65,7 +65,18 @@ export class MyInfoResponseDto {
   @ApiProperty({ description: 'GitHub 링크', example: 'https://github.com/jennywithlove' })
   github: string;
 
-  @ApiProperty({ description: '사용자 경력', type: [CareerDto] })
+  @ApiProperty({ 
+    description: '사용자 경력', 
+    type: [CareerDto],
+    example: [
+      {
+        name: 'Google',
+        periodStart: '2020-01-01',
+        periodEnd: '2022-01-01',
+        role: 'Software Engineer',
+      },
+    ],
+  })
   career: CareerDto[]; // JSON 필드 반영
 
   @ApiProperty({

--- a/src/modules/user/dto/my-info-response.dto.ts
+++ b/src/modules/user/dto/my-info-response.dto.ts
@@ -75,6 +75,12 @@ export class MyInfoResponseDto {
         periodEnd: '2022-01-01',
         role: 'Software Engineer',
       },
+      {
+        name: 'Facebook',
+        periodStart: '2018-06-01',
+        periodEnd: '2019-12-31',
+        role: 'Backend Developer',
+      },
     ],
   })
   career: CareerDto[]; // JSON 필드 반영
@@ -91,6 +97,7 @@ export class MyInfoResponseDto {
     type: [SkillDto],
     example: [
       { skillName: 'JavaScript', skillImg: 'https://example.com/js-logo.png' },
+      { skillName: 'TypeScript', skillImg: 'https://example.com/TypeScript-logo.png' },
       { skillName: 'React', skillImg: 'https://example.com/react-logo.png' },
     ],
   })

--- a/src/modules/user/dto/my-info-response.dto.ts
+++ b/src/modules/user/dto/my-info-response.dto.ts
@@ -2,7 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsOptional,
-  IsString
+  IsString,
+  ValidateNested
 } from 'class-validator';
 
 class SkillDto {
@@ -30,12 +31,12 @@ export class CareerDto {
   @ApiProperty({ description: '시작 날짜', example: '2020-01-01' })
   @Type(() => Date)
   @IsOptional()
-  periodStart: string;
+  periodStart: Date;
 
   @ApiProperty({ description: '종료 날짜', example: '2022-01-01' })
   @Type(() => Date)
   @IsOptional()
-  periodEnd: string;
+  periodEnd: Date;
 
   @ApiProperty({ description: '역할/포지션', example: 'Software Engineer' })
   @IsString()
@@ -65,8 +66,9 @@ export class MyInfoResponseDto {
   @ApiProperty({ description: 'GitHub 링크', example: 'https://github.com/jennywithlove' })
   github: string;
 
-  @ApiProperty({ 
-    description: '사용자 경력', 
+
+  @ApiProperty({
+    description: '경력사항/수상이력',
     type: [CareerDto],
     example: [
       {
@@ -83,7 +85,10 @@ export class MyInfoResponseDto {
       },
     ],
   })
-  career: CareerDto[]; // JSON 필드 반영
+  @ValidateNested({ each: true })
+  @IsOptional()
+  @Type(() => CareerDto)
+  career?: CareerDto[] | null;
 
   @ApiProperty({
     description: '포지션 태그 정보',

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,21 +1,27 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsArray } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsOptional, IsString, IsArray, ValidateNested } from 'class-validator';
+
 
 export class CareerDto {
   @ApiProperty({ description: '회사 이름', example: 'Google' })
   @IsString()
+  @IsOptional()
   name: string;
 
   @ApiProperty({ description: '시작 날짜', example: '2020-01-01' })
-  @IsString()
-  periodStart: string;
+  @Type(() => Date)
+  @IsOptional()
+  periodStart: Date;
 
   @ApiProperty({ description: '종료 날짜', example: '2022-01-01' })
-  @IsString()
-  periodEnd: string;
+  @Type(() => Date)
+  @IsOptional()
+  periodEnd: Date;
 
   @ApiProperty({ description: '역할/포지션', example: 'Software Engineer' })
   @IsString()
+  @IsOptional()
   role: string;
 }
 
@@ -49,7 +55,8 @@ export class UpdateUserDto {
   skillTagIds?: number[];
 
   @ApiProperty({
-    description: '경력 배열',
+    description: '경력사항/수상이력',
+    type: [CareerDto],
     example: [
       {
         name: 'Google',
@@ -62,11 +69,11 @@ export class UpdateUserDto {
         periodStart: '2018-06-01',
         periodEnd: '2019-12-31',
         role: 'Backend Developer',
-      },      
+      },
     ],
-    type: [CareerDto],
   })
+  @ValidateNested({ each: true })
   @IsOptional()
-  @IsArray()
-  career?: CareerDto[];
+  @Type(() => CareerDto)
+  career?: CareerDto[] | null;
 }

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsArray } from 'class-validator';
+
+export class CareerDto {
+  @ApiProperty({ description: '회사 이름', example: 'Google' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({ description: '시작 날짜', example: '2020-01-01' })
+  @IsString()
+  periodStart: string;
+
+  @ApiProperty({ description: '종료 날짜', example: '2022-01-01' })
+  @IsString()
+  periodEnd: string;
+
+  @ApiProperty({ description: '역할/포지션', example: 'Software Engineer' })
+  @IsString()
+  role: string;
+}
+
+export class UpdateUserDto {
+  @ApiProperty({ description: '사용자 닉네임', example: 'newNickname' })
+  @IsOptional()
+  @IsString()
+  nickname?: string;
+
+  @ApiProperty({ description: '사용자 소개 (bio)', example: '새로운 소개글입니다.' })
+  @IsOptional()
+  @IsString()
+  bio?: string;
+
+  @ApiProperty({ description: 'GitHub 링크', example: 'https://github.com/example' })
+  @IsOptional()
+  @IsString()
+  github?: string;
+
+  @ApiProperty({ description: '포지션 태그 ID', example: 2 })
+  @IsOptional()
+  positionTagId?: number;
+
+  @ApiProperty({
+    description: '스킬 태그 ID 배열',
+    example: [1, 2, 3],
+    type: [Number],
+  })
+  @IsOptional()
+  @IsArray()
+  skillTagIds?: number[];
+
+  @ApiProperty({
+    description: '경력 배열',
+    example: [
+      {
+        name: 'Google',
+        periodStart: '2020-01-01',
+        periodEnd: '2022-01-01',
+        role: 'Software Engineer',
+      },
+      {
+        name: 'Facebook',
+        periodStart: '2018-06-01',
+        periodEnd: '2019-12-31',
+        role: 'Backend Developer',
+      },      
+    ],
+    type: [CareerDto],
+  })
+  @IsOptional()
+  @IsArray()
+  career?: CareerDto[];
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -338,8 +338,6 @@ export class UserController {
 
   @Put('me')
   @HttpCode(HttpStatus.OK)
-  @UseGuards(JwtAuthGuard)
-  @ApiBearerAuth('JWT')
   @ApiOperation({
     summary: '내 정보 수정',
     description: '사용자의 정보를 수정합니다.',
@@ -371,6 +369,8 @@ export class UserController {
       },
     },
   })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
   async putUpdateMe(
     @CurrentUser() userId: number,
     @Body() updateUserDto: UpdateUserDto,

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -11,6 +11,7 @@ import {
   UseInterceptors,
   UploadedFile,
   Get,
+  Put,
   Param,
   UseGuards,
   InternalServerErrorException 
@@ -23,6 +24,7 @@ import { JwtAuthGuard } from '../auth/guard/jwt-auth.guard';
 import { CheckNicknameDto } from './dto/check-nickname.dto';
 import { ApplicationStatusDto } from './dto/application-status.dto';
 import { MyInfoResponseDto } from './dto/my-info-response.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -222,106 +224,160 @@ export class UserController {
     return applications;
   }
 
-// 내 정보 조회
-@Get('me')
-@HttpCode(HttpStatus.OK)
-@ApiOperation({
-  summary: '내 정보 보기',
-  description: '인증된 사용자의 정보를 반환하며, 포지션, 깃허브 링크, 경력, 스킬셋 등을 포함합니다.',
-})
-@ApiResponse({
-  status: 200,
-  description: '사용자의 정보 반환',
-  type: MyInfoResponseDto,
-})
-@ApiResponse({
-  status: 401,
-  description: '인증 실패',
-  schema: {
-    example: {
-      statusCode: 401,
-      message: '유효하지 않거나 만료된 토큰입니다.',
-      error: 'Unauthorized',
+  // 내 정보 조회
+  @Get('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '내 정보 보기',
+    description: '인증된 사용자의 정보를 반환하며, 포지션, 깃허브 링크, 경력, 스킬셋 등을 포함합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자의 정보 반환',
+    type: MyInfoResponseDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않거나 만료된 토큰입니다.',
+        error: 'Unauthorized',
+      },
     },
-  },
-})
-@ApiResponse({
-  status: 404,
-  description: '사용자 정보가 존재하지 않을 경우',
-  schema: {
-    example: {
-      statusCode: 404,
-      message: '사용자 정보를 찾을 수 없습니다.',
-      error: 'Not Found',
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자 정보가 존재하지 않을 경우',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자 정보를 찾을 수 없습니다.',
+        error: 'Not Found',
+      },
     },
-  },
-})
-@ApiBearerAuth('JWT')
-@UseGuards(JwtAuthGuard) // 401 에러 처리
-async getMyInfo(@CurrentUser() userId: number): Promise<MyInfoResponseDto> {
-  if (!userId) {
-    throw new UnauthorizedException('인증되지 않은 사용자입니다.');
+  })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard) // 401 에러 처리
+  async getMyInfo(@CurrentUser() userId: number): Promise<MyInfoResponseDto> {
+    if (!userId) {
+      throw new UnauthorizedException('인증되지 않은 사용자입니다.');
+    }
+
+    const userInfo = await this.userService.getUserInfoWithSkills(userId);
+
+    if (!userInfo) {
+      throw new NotFoundException('사용자 정보를 찾을 수 없습니다.');
+    }
+
+    // career가 비어 있는 경우 빈 배열 반환
+    if (!userInfo.career || userInfo.career.length === 0) {
+    userInfo.career = [];
+    }
+
+    return userInfo;
   }
 
-  const userInfo = await this.userService.getUserInfoWithSkills(userId);
+  // 다른 사용자 정보 조회
+  @Get(':id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '다른 사용자 정보 보기',
+    description: '특정 사용자의 정보를 반환합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자의 정보 반환',
+    type: MyInfoResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 - 사용자 ID 형식이 잘못되었거나 누락됨',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '잘못된 사용자 ID입니다.',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자 정보가 존재하지 않을 경우',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자 정보를 찾을 수 없습니다.',
+        error: 'Not Found',
+      },
+    },
+  })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
+  async getOtherUserInfo(@Param('id') id: string): Promise<MyInfoResponseDto> {
+    const userId = parseInt(id, 10); // 숫자로 변환
 
-  if (!userInfo) {
-    throw new NotFoundException('사용자 정보를 찾을 수 없습니다.');
+    if (isNaN(userId)) {
+      throw new BadRequestException('잘못된 사용자 ID입니다.');
+    }
+
+    const userInfo = await this.userService.getUserInfoWithSkills(userId);
+
+    if (!userInfo) {
+      throw new NotFoundException('사용자 정보를 찾을 수 없습니다.');
+    }
+
+    // career가 비어 있는 경우 빈 배열 반환
+    if (!userInfo.career || userInfo.career.length === 0) {
+      userInfo.career = [];
+    }
+
+    return userInfo;
   }
 
-  return userInfo;
+  @Put('me')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT')
+  @ApiOperation({
+    summary: '내 정보 수정',
+    description: '사용자의 정보를 수정합니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자 정보가 성공적으로 수정되었습니다.',
+    type: MyInfoResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 요청 데이터 형식',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '잘못된 데이터 형식입니다.',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않거나 만료된 토큰입니다.',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  async putUpdateMe(
+    @CurrentUser() userId: number,
+    @Body() updateUserDto: UpdateUserDto,
+  ): Promise<MyInfoResponseDto> {
+    return await this.userService.updateUser(userId, updateUserDto);
+  }
+
+
 }
 
-// 다른 사용자 정보 조회
-@Get(':id')
-@HttpCode(HttpStatus.OK)
-@ApiOperation({
-  summary: '다른 사용자 정보 보기',
-  description: '특정 사용자의 정보를 반환합니다.',
-})
-@ApiResponse({
-  status: 200,
-  description: '사용자의 정보 반환',
-  type: MyInfoResponseDto,
-})
-@ApiResponse({
-  status: 400,
-  description: '잘못된 요청 - 사용자 ID 형식이 잘못되었거나 누락됨',
-  schema: {
-    example: {
-      statusCode: 400,
-      message: '잘못된 사용자 ID입니다.',
-      error: 'Bad Request',
-    },
-  },
-})
-@ApiResponse({
-  status: 404,
-  description: '사용자 정보가 존재하지 않을 경우',
-  schema: {
-    example: {
-      statusCode: 404,
-      message: '사용자 정보를 찾을 수 없습니다.',
-      error: 'Not Found',
-    },
-  },
-})
-@ApiBearerAuth('JWT')
-@UseGuards(JwtAuthGuard)
-async getOtherUserInfo(@Param('id') id: string): Promise<MyInfoResponseDto> {
-  const userId = parseInt(id, 10); // 숫자로 변환
-
-  if (isNaN(userId)) {
-    throw new BadRequestException('잘못된 사용자 ID입니다.');
-  }
-
-  const userInfo = await this.userService.getUserInfoWithSkills(userId);
-
-  if (!userInfo) {
-    throw new NotFoundException('사용자 정보를 찾을 수 없습니다.');
-  }
-
-  return userInfo;
-}
-
-}

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -4,9 +4,10 @@ import { UserService } from './user.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { UploadModule } from '../upload/upload.module';
 import { AuthModule } from '../auth/auth.module';
+import { SkillTagModule } from '../skill-tag/skill-tag.module';
 
 @Module({
-  imports: [UploadModule, AuthModule],
+  imports: [UploadModule, AuthModule, SkillTagModule],
   controllers: [UserController],
   providers: [UserService, PrismaService],
   exports: [UserService],

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -5,9 +5,10 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UploadModule } from '../upload/upload.module';
 import { AuthModule } from '../auth/auth.module';
 import { SkillTagModule } from '../skill-tag/skill-tag.module';
+import { PositionTagModule } from '../position-tag/position-tag.module';
 
 @Module({
-  imports: [UploadModule, AuthModule, SkillTagModule],
+  imports: [UploadModule, AuthModule, SkillTagModule, PositionTagModule],
   controllers: [UserController],
   providers: [UserService, PrismaService],
   exports: [UserService],

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -199,12 +199,7 @@ export class UserService {
       // 포지션 태그 유효성 검증
       const positionTag = await this.positionTagService.fetchPositionTag({ id: positionTagId });
   
-      // 기존 포지션 태그 삭제 후 업데이트
-      await this.prisma.user.update({
-        where: { id: userId },
-        data: { positionTagId: null },
-      });
-  
+      // 기존 포지션 태그 업데이트
       await this.prisma.user.update({
         where: { id: userId },
         data: { positionTagId: positionTag.id },

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import * as bcrypt from 'bcrypt';
 import { UploadService } from '../upload/upload.service';
 import { SkillTagService } from '../skill-tag/skill-tag.service';
+import { PositionTagService } from '../position-tag/position-tag.service';
 import { ApplicationStatusDto } from './dto/application-status.dto';
 import { CareerDto } from './dto/my-info-response.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -15,7 +16,7 @@ export class UserService {
     private readonly prisma: PrismaService,
     private s3Service: UploadService,
     private skillTagService : SkillTagService,
-    private positionTagService : SkillTagService,
+    private positionTagService : PositionTagService,
   ) {}
 
   async checkNicknameAvailability(nickname: string): Promise<boolean> {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,15 +1,21 @@
-import { Injectable, BadRequestException, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, BadRequestException, InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import * as bcrypt from 'bcrypt';
 import { UploadService } from '../upload/upload.service';
+import { SkillTagService } from '../skill-tag/skill-tag.service';
 import { ApplicationStatusDto } from './dto/application-status.dto';
-import { CareerDto } from './dto/my-info-response.dto'
+import { CareerDto } from './dto/my-info-response.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { MyInfoResponseDto } from './dto/my-info-response.dto';
+
 
 @Injectable()
 export class UserService {
   constructor(
     private readonly prisma: PrismaService,
     private s3Service: UploadService,
+    private skillTagService : SkillTagService,
+    private positionTagService : SkillTagService,
   ) {}
 
   async checkNicknameAvailability(nickname: string): Promise<boolean> {
@@ -123,7 +129,7 @@ export class UserService {
     }
   }
 
-  async getUserInfoWithSkills(userId: number) {
+  async getUserInfoWithSkills(userId: number): Promise<MyInfoResponseDto | null> {
     if (!userId || typeof userId !== 'number') {
       return null; // 사용자 ID가 잘못된 경우 null 반환
     }
@@ -132,18 +138,12 @@ export class UserService {
       where: { id: userId },
       include: {
         positionTag: {
-          select: {
-            id: true,
-            name: true,
-          },
+          select: { id: true, name: true },
         },
         UserSkillTag: {
           include: {
             SkillTag: {
-              select: {
-                name: true,
-                img: true,
-              },
+              select: { name: true, img: true },
             },
           },
         },
@@ -154,12 +154,16 @@ export class UserService {
       return null; // 사용자 정보가 없는 경우 null 반환
     }
   
-    // `career` 필드를 안전하게 파싱
-    const parsedCareer: CareerDto[] = userWithSkills.career
-  ? (userWithSkills.career as any as CareerDto[]) // 타입 단언 사용
-  : [];
-
+    // `career` 필드 파싱
+    let parsedCareer: CareerDto[] = [];
+    try {
+      const careerData = userWithSkills.career as unknown as string; // 문자열로 변환
+      parsedCareer = careerData ? JSON.parse(careerData) : []; // JSON 파싱
+    } catch (error) {
+      console.error('Error parsing career field:', error);
+    }
   
+    
     return {
       id: userWithSkills.id,
       nickname: userWithSkills.nickname,
@@ -176,6 +180,78 @@ export class UserService {
       })),
       createdAt: userWithSkills.createdAt,
     };
+  }
+
+  async updateUser(userId: number, updateUserDto: UpdateUserDto): Promise<MyInfoResponseDto> {
+    const { positionTagId, skillTagIds, career, ...updateData } = updateUserDto;
+  
+    // 유저 확인
+    const existingUser = await this.prisma.user.findUnique({
+      where: { id: userId },
+    });
+    if (!existingUser) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+  
+    // 포지션 태그 검증 및 업데이트
+    if (positionTagId) {
+      // 포지션 태그 유효성 검증
+      const positionTag = await this.positionTagService.fetchPositionTag({ id: positionTagId });
+  
+      // 기존 포지션 태그 삭제 후 업데이트
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: { positionTagId: null },
+      });
+  
+      await this.prisma.user.update({
+        where: { id: userId },
+        data: { positionTagId: positionTag.id },
+      });
+    }
+  
+    // 스킬 태그 삭제 후 추가
+    if (skillTagIds && skillTagIds.length > 0) {
+      // 스킬 태그 검증
+      const skillTags = await Promise.all(
+        skillTagIds.map((id) => this.skillTagService.fetchSkillTag({ id })),
+      );
+  
+      // 기존 스킬 태그 삭제
+      await this.prisma.userSkillTag.deleteMany({
+        where: { userId },
+      });
+  
+      // 새로운 스킬 태그 생성
+      await this.prisma.userSkillTag.createMany({
+        data: skillTags.map((tag) => ({
+          userId,
+          skillTagId: tag.id,
+        })),
+      });
+    }
+  
+    // `career` 필드 JSON으로 변환
+    let careerJson = null;
+    if (career) {
+      try {
+        careerJson = JSON.stringify(career);
+      } catch (error) {
+        throw new BadRequestException('잘못된 career 데이터 형식입니다.');
+      }
+    }
+  
+    // 사용자 정보 업데이트
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        ...updateData,
+        career: careerJson,
+      },
+    });
+  
+    // 업데이트된 데이터 가져오기
+    return this.getUserInfoWithSkills(userId);
   }
 
 }


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

- ✨ **내 정보 수정 및 조회 API 개선**
  - `career` 필드에 대해:
    -  ~~내 정보 보기 JSON 파싱 추가 (`JSON.parse`)~~ → 현희님 코드 적용으로 필요 없어서 삭제!
    - 빈 값일 경우, 기본값으로 빈 배열(`[]`) 반환 처리.  → 컨트롤러 부분 수정 X
    - ~~내 정보 수정 시, 클라이언트 데이터 JSON 직렬화 (`JSON.stringify`) 후 저장.~~ → 현희님 코드 적용으로 수정 완료!
    ```tsc
     // `career` 필드 JSON으로 변환 및 Prisma InputJsonValue로 처리
    const careerJson = career
      ? (career as unknown as Prisma.InputJsonValue)
      : null;
      ```
  - **내 정보 수정 로직 - 포지션 태그 및 스킬 태그 현희님 코드 적용 완료!**
    - 포지션 태그 유효성 검증 로직 추가. 
     ~~포지션 태그 폴더 만들기는 애매해서 `skill-tag.service.ts`에 추가했습니다!~~
     → 포지션 태그 폴더 있는데 너무 많이 폴더를 열어놔서 확인을 못했던 것...😭 수정 완료 했습니당👍

---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [x] `career` 필드의 파싱 및 직렬화 방식에 대해 추가 개선 필요 여부.
  ~~파싱을 안하고 기존 코드로 하니까 오류가 발생해서 수정했습니다!
  `career` 필드가 객체 배열(`CareerDto[]`) 형태로 반환되어야 하므로, JSON 문자열을 파싱해야 한다고 하여 수정!~~
  →  현희님 코드 적용으로 기존의 내 정보 보기에서는 JSON 파싱 삭제, 내 정보 수정에서는 현희님 코드 적용으로,
  DB에 \가 저장되지 않도록 완료!
  
        ```tsc
       // `career` 필드 JSON으로 변환 및 Prisma InputJsonValue로 처리
      const careerJson = career
        ? (career as unknown as Prisma.InputJsonValue)
        : null;
        ```
  
  | **DB에 잘 저장되는 모습!**               |
|--------------------------------------|
| ![image](https://github.com/user-attachments/assets/8d1b9a7b-9697-437b-8a5c-b36d8b02263c)   | 
  

---

# 🖼️ 결과 이미지 (Screenshots)

| **내 정보 보기**               | **내 정보 수정**                |
|--------------------------------------|--------------------------------------|
| ![image](https://github.com/user-attachments/assets/da479de9-4b81-4b44-a3ac-1ca73c728329)   | ![image](https://github.com/user-attachments/assets/d3a0cb40-2a04-4c7c-8dd3-d4ba02284b6a)      |




---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

필요시 수정하겠습니다!!👍

---

# 📝 참고 사항 (Additional notes)

- **테스트 방법**:
  1. 내 정보 조회 API (`GET /user/me`) 호출.
  2. 내 정보 수정 API (`PUT /user/me`) 수정할 데이터를 넣고 호출!
