### PR TITLE
[Feat] 참여 프로젝트 조회 및 관련 로직 및 DTO 수정

### DIFF
--- a/src/modules/user/dto/get-accepted-projects.dto.ts
+++ b/src/modules/user/dto/get-accepted-projects.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetAcceptedProjectsDto {
+  @ApiProperty({
+    description: '유저 ID (유저 조회 페이지에서 사용)',
+    example: 1,
+    required: false,
+  })
+  userId?: number;
+}

--- a/src/modules/user/dto/project-response.dto.ts
+++ b/src/modules/user/dto/project-response.dto.ts
@@ -1,0 +1,85 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsBoolean, IsNumber } from 'class-validator';
+import { Type } from 'class-transformer';
+
+
+export class SkillTagDto {
+  @ApiProperty({ description: '스킬 태그 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '스킬 태그 이름', example: 'JavaScript' })
+  name: string;
+
+  @ApiProperty({ description: '스킬 이미지 URL', example: 'https://example.com/js-logo.png' })
+  img: string;
+}
+
+export class ProjectSkillTagDto {
+  @ApiProperty({ description: '프로젝트 ID', example: 10 })
+  projectId: number;
+
+  @ApiProperty({ description: '스킬 태그 ID', example: 1 })
+  skillTagId: number;
+
+  @ApiProperty({ description: '스킬 태그', type: SkillTagDto })
+  SkillTag: SkillTagDto;
+}
+
+export class PositionTagDto {
+  @ApiProperty({ description: '포지션 태그 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '포지션 태그 이름', example: '백엔드' })
+  name: string;
+}
+
+
+export class ProjectPositionTagDto {
+  @ApiProperty({ description: '프로젝트 ID', example: 10 })
+  projectId: number;
+
+  @ApiProperty({ description: '포지션 태그 ID', example: 1 })
+  positionTagId: number;
+
+  @ApiProperty({ description: '포지션 태그', type: PositionTagDto })
+  PositionTag: PositionTagDto;
+}
+
+export class ProjectResponseDto {
+  @ApiProperty({ description: '프로젝트 ID', example: 10 })
+  projectId: number;
+
+  @ApiProperty({ description: '프로젝트 제목', example: '클론코딩 사이드 프로젝트 모집 공고' })
+  title: string;
+
+  @ApiProperty({ description: '프로젝트 설명', example: 'string' })
+  description: string;
+
+  @ApiProperty({ description: '프로젝트 시작 날짜', example: '2025-01-25T00:00:00.000Z' })
+  startDate: string;
+
+  @ApiProperty({ description: '예상 기간', example: '3개월' })
+  estimatedPeriod: string;
+
+  @ApiProperty({ description: '초보자 참여 가능 여부', example: true })
+  isBeginner: boolean;
+
+  @ApiProperty({ description: '진행 방식 ID', example: 1 })
+  methodId: number;
+
+  @ApiProperty({ description: '모집 시작 날짜', example: '2025-01-06T00:00:00.000Z' })
+  recruitmentStartDate: string;
+
+  @ApiProperty({ description: '모집 마감 날짜', example: '2025-02-15T00:00:00.000Z' })
+  recruitmentEndDate: string;
+
+  @ApiProperty({ description: '지원 상태', example: 'ACCEPTED' })
+  status: string;
+
+  @ApiProperty({ description: '프로젝트 스킬 태그 목록', type: [ProjectSkillTagDto] })
+  ProjectSkillTag: ProjectSkillTagDto[];
+
+  @ApiProperty({ description: '프로젝트 포지션 태그 목록', type: [ProjectPositionTagDto] })
+  ProjectPositionTag: ProjectPositionTagDto[];
+}
+

--- a/src/modules/user/dto/project-response.dto.ts
+++ b/src/modules/user/dto/project-response.dto.ts
@@ -65,11 +65,14 @@ export class ProjectResponseDto {
   @ApiProperty({ description: '예상 기간', example: '3개월' })
   estimatedPeriod: string;
 
+  @ApiProperty({ description: '진행 방식 ID', example: 1 })
+  methodId: number;
+
   @ApiProperty({ description: '초보자 참여 가능 여부', example: true })
   isBeginner: boolean;
 
-  @ApiProperty({ description: '진행 방식 ID', example: 1 })
-  methodId: number;
+  @ApiProperty({ description: '프로젝트 마감 현황', example: true })
+  isDone: boolean;
 
   @ApiProperty({ description: '모집 시작 날짜', example: '2025-01-06T00:00:00.000Z' })
   recruitmentStartDate: string;

--- a/src/modules/user/dto/project-response.dto.ts
+++ b/src/modules/user/dto/project-response.dto.ts
@@ -1,6 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsBoolean, IsNumber } from 'class-validator';
-import { Type } from 'class-transformer';
 
 
 export class SkillTagDto {
@@ -54,6 +52,12 @@ export class ProjectResponseDto {
 
   @ApiProperty({ description: '프로젝트 설명', example: 'string' })
   description: string;
+
+  @ApiProperty({
+    example: 3,
+    description: '모집 인원',
+  })
+  totalMember: number;
 
   @ApiProperty({ description: '프로젝트 시작 날짜', example: '2025-01-25T00:00:00.000Z' })
   startDate: string;

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -26,6 +26,7 @@ import { ApplicationStatusDto } from './dto/application-status.dto';
 import { MyInfoResponseDto } from './dto/my-info-response.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { GetAcceptedProjectsDto } from './dto/get-accepted-projects.dto';
+import { ProjectResponseDto } from './dto/project-response.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -389,20 +390,7 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: '사용자가 참여한 프로젝트 목록',
-    schema: {
-      example: [
-        {
-          projectId: 1,
-          title: '클론코딩 사이드 프로젝트 모집',
-          description: '백엔드와 프론트엔드 협업 프로젝트',
-          startDate: '2025-01-01T00:00:00.000Z',
-          estimatedPeriod: '3개월',
-          isBeginner: true,
-          skills: ['JavaScript', 'TypeScript'],
-          positions: ['백엔드', '프론트엔드'],
-        },
-      ],
-    },
+    type: [ProjectResponseDto],
   })
   @ApiResponse({
     status: 401,
@@ -431,20 +419,7 @@ export class UserController {
   @ApiResponse({
     status: 200,
     description: '특정 사용자가 참여한 프로젝트 목록',
-    schema: {
-      example: [
-        {
-          projectId: 1,
-          title: '클론코딩 사이드 프로젝트 모집',
-          description: '백엔드와 프론트엔드 협업 프로젝트',
-          startDate: '2025-01-01T00:00:00.000Z',
-          estimatedPeriod: '3개월',
-          isBeginner: true,
-          skills: ['JavaScript', 'TypeScript'],
-          positions: ['백엔드', '프론트엔드'],
-        },
-      ],
-    },
+    type: [ProjectResponseDto],
   })
   @ApiResponse({
     status: 400,

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -25,6 +25,7 @@ import { CheckNicknameDto } from './dto/check-nickname.dto';
 import { ApplicationStatusDto } from './dto/application-status.dto';
 import { MyInfoResponseDto } from './dto/my-info-response.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { GetAcceptedProjectsDto } from './dto/get-accepted-projects.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -378,6 +379,114 @@ export class UserController {
     return await this.userService.updateUser(userId, updateUserDto);
   }
 
+  
+  @Get('me/project')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '참여 프로젝트 조회 (내 프로젝트)',
+    description: '현재 인증된 사용자가 참여한 프로젝트 목록을 반환합니다. "합격된" 프로젝트만 포함됩니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '사용자가 참여한 프로젝트 목록',
+    schema: {
+      example: [
+        {
+          projectId: 1,
+          title: '클론코딩 사이드 프로젝트 모집',
+          description: '백엔드와 프론트엔드 협업 프로젝트',
+          startDate: '2025-01-01T00:00:00.000Z',
+          estimatedPeriod: '3개월',
+          isBeginner: true,
+          skills: ['JavaScript', 'TypeScript'],
+          positions: ['백엔드', '프론트엔드'],
+        },
+      ],
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않거나 만료된 토큰입니다.',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
+  async getManyMyAcceptedProjects(@CurrentUser() userId: number) {
+    return await this.userService.fetchManyAcceptedProjects(userId);
+  }
+
+  @Get(':id/project')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: '참여 프로젝트 조회 (특정 사용자)',
+    description:
+      '특정 사용자가 참여한 프로젝트 목록을 반환합니다. 경로 파라미터로 사용자 ID를 전달해야 하며, "합격된" 프로젝트만 포함됩니다.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '특정 사용자가 참여한 프로젝트 목록',
+    schema: {
+      example: [
+        {
+          projectId: 1,
+          title: '클론코딩 사이드 프로젝트 모집',
+          description: '백엔드와 프론트엔드 협업 프로젝트',
+          startDate: '2025-01-01T00:00:00.000Z',
+          estimatedPeriod: '3개월',
+          isBeginner: true,
+          skills: ['JavaScript', 'TypeScript'],
+          positions: ['백엔드', '프론트엔드'],
+        },
+      ],
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: '잘못된 사용자 ID 요청',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: '잘못된 사용자 ID입니다.',
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: '인증 실패',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: '유효하지 않거나 만료된 토큰입니다.',
+        error: 'Unauthorized',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 404,
+    description: '사용자 정보를 찾을 수 없음',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: '사용자를 찾을 수 없습니다.',
+        error: 'Not Found',
+      },
+    },
+  })
+  @ApiBearerAuth('JWT')
+  @UseGuards(JwtAuthGuard)
+  async getManyUserAcceptedProjects(@Param() params: GetAcceptedProjectsDto) {
+    const { userId } = params;
+    return await this.userService.fetchManyAcceptedProjects(userId);
+  }
+
 
 }
+
 

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -254,4 +254,48 @@ export class UserService {
     return this.getUserInfoWithSkills(userId);
   }
 
+  async fetchManyAcceptedProjects(userId: number) {
+    const applicants = await this.prisma.applicant.findMany({
+      where: {
+        userId,
+        status: 'ACCEPTED',
+      },
+      include: {
+        Project: {
+          include: {
+            ProjectSkillTag: {
+              include: { SkillTag: true },
+            },
+            ProjectPositionTag: {
+              include: { PositionTag: true },
+            },
+          },
+        },
+      },
+    });
+  
+    // 필요한 정보만 가공
+    return applicants.map((applicant) => {
+      const project = applicant.Project;
+      return {
+        projectId: project.id,
+        title: project.title,
+        description: project.description,
+        startDate: project.startDate,
+        estimatedPeriod: project.estimatedPeriod,
+        isBeginner: project.isBeginner,
+        status: applicant.status, // ACCEPTED 상태만 포함
+        skills: project.ProjectSkillTag.map((tag) => ({
+          id: tag.SkillTag.id,
+          name: tag.SkillTag.name,
+          img: tag.SkillTag.img,
+        })),
+        positions: project.ProjectPositionTag.map((tag) => ({
+          id: tag.PositionTag.id,
+          name: tag.PositionTag.name,
+        })),
+      };
+    });
+  }
+
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -265,6 +265,7 @@ export class UserService {
         projectId: project.id,
         title: project.title,
         description: project.description,
+        totalMember: project.totalMember,
         startDate: project.startDate.toISOString(),
         estimatedPeriod: project.estimatedPeriod,
         isBeginner: project.isBeginner,

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -268,8 +268,9 @@ export class UserService {
         totalMember: project.totalMember,
         startDate: project.startDate.toISOString(),
         estimatedPeriod: project.estimatedPeriod,
-        isBeginner: project.isBeginner,
         methodId: project.methodId,
+        isBeginner: project.isBeginner,
+        isDone : project.isDone,
         recruitmentStartDate: project.recruitmentStartDate.toISOString(),
         recruitmentEndDate: project.recruitmentEndDate.toISOString(),
         status: 'ACCEPTED', // 항상 ACCEPTED 상태 유지


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

- ✨ 주요 기능:
  - [x] 참여 프로젝트 조회 (내 프로젝트 및 다른 사용자 프로젝트) 기능 추가
  - [x] 참여 프로젝트 관련 DTO 구현 및 사용
  - [x] 컨트롤러에서 DTO 출력하도록 수정

---

# 🤔 논의가 필요한 사항 (Points to discuss)

- [ ] 응답 데이터 구조의 추가 개선 필요 여부
   일단 현희님이 만드셨던 GET /project/my (기획자가 등록한 공고 목록)을 참고하여
   필요하다구 생각된 데이터들을 더 추가로 수정해서 넣었습니당!
   (출력 데이터에 수정이 필요하다면 할 예정이에용)

---

# 🖼️ 결과 이미지 (Screenshots)

| **내가 참여한 프로젝트 조회**               | **다른 사용자가 참여한 프로젝트 조회**                |
|-----------------------------|-----------------------------|
| ![image](https://github.com/user-attachments/assets/cce04982-065d-44de-b3e5-46ab0bd77396)   | ![image](https://github.com/user-attachments/assets/9e978cbb-e80b-4891-8b3b-dc6737ca6464)   |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

수정이 필요할 시 수정하겠습니당!

---

# 📝 참고 사항 (Additional notes)

- **테스트 방법**:
  1. `GET /user/me/project` 호출!
  2. `GET /user/:id/project` 호출!
