### PR TITLE
[Feat] 특정 사용자 참여 및 기획 프로젝트 조회 기능 추가 및 수정

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -64,6 +64,17 @@ export class AuthController {
       },
     },
   })
+  @ApiResponse({
+    status: 500,
+    description: '서버 오류 - 닉네임 중복',
+    schema: {
+      example: {
+        statusCode: 500,
+        message: '이미 사용 중인 닉네임입니다.',
+        error: 'Internal Server Error',
+      },
+    },
+  })
   async postSignUp(@Body() signUpDto: SignUpDto) {
     const result = await this.authService.signUp(signUpDto);
     return result; // authService.signUp()의 응답을 그대로 반환

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -69,7 +69,7 @@ export class AuthController {
     description: '서버 오류 - 닉네임 중복',
     schema: {
       example: {
-        statusCode: 500,
+        statusCode: 400,
         message: '이미 사용 중인 닉네임입니다.',
         error: 'Bad Request',
       },

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -65,13 +65,13 @@ export class AuthController {
     },
   })
   @ApiResponse({
-    status: 500,
+    status: 400,
     description: '서버 오류 - 닉네임 중복',
     schema: {
       example: {
         statusCode: 500,
         message: '이미 사용 중인 닉네임입니다.',
-        error: 'Internal Server Error',
+        error: 'Bad Request',
       },
     },
   })

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -2,7 +2,6 @@ import {
   Injectable,
   BadRequestException,
   UnauthorizedException,
-  InternalServerErrorException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
@@ -34,7 +33,7 @@ export class AuthService {
     // 닉네임 중복 체크
     const isNicknameAvailable = await this.userService.checkNicknameAvailability(nickname);
     if (!isNicknameAvailable) {
-      throw new InternalServerErrorException('이미 사용 중인 닉네임입니다.');
+      throw new BadRequestException('이미 사용 중인 닉네임입니다.');
     }
 
     // 비밀번호 해싱

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   BadRequestException,
   UnauthorizedException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PrismaService } from '../prisma/prisma.service';
@@ -28,6 +29,12 @@ export class AuthService {
       await this.userService.checkEmailAvailability(email);
     if (!isEmailAvailable) {
       throw new BadRequestException('이미 사용 중인 이메일입니다.');
+    }
+
+    // 닉네임 중복 체크
+    const isNicknameAvailable = await this.userService.checkNicknameAvailability(nickname);
+    if (!isNicknameAvailable) {
+      throw new InternalServerErrorException('이미 사용 중인 닉네임입니다.');
     }
 
     // 비밀번호 해싱

--- a/src/modules/user/dto/project-response.dto.ts
+++ b/src/modules/user/dto/project-response.dto.ts
@@ -81,7 +81,7 @@ export class ProjectResponseDto {
   recruitmentEndDate: string;
 
   @ApiProperty({ description: '지원 상태', example: 'ACCEPTED' })
-  status: string;
+  status?: string;
 
   @ApiProperty({ description: '프로젝트 스킬 태그 목록', type: [ProjectSkillTagDto] })
   ProjectSkillTag: ProjectSkillTagDto[];

--- a/src/modules/user/dto/user-projects-response.dto.ts
+++ b/src/modules/user/dto/user-projects-response.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ProjectResponseDto } from './project-response.dto';
+
+export class UserProjectsResponseDto {
+  @ApiProperty({
+    description: '사용자가 참여한 프로젝트 목록',
+    type: [ProjectResponseDto],
+    example: [
+      {
+        projectId: 1,
+        title: '참여한 프로젝트',
+        description: '참여한 프로젝트 설명',
+        totalMember: 5,
+        startDate: '2025-01-01T00:00:00.000Z',
+        estimatedPeriod: '3개월',
+        methodId: 1,
+        isBeginner: true,
+        isDone: false,
+        recruitmentStartDate: '2025-01-01T00:00:00.000Z',
+        recruitmentEndDate: '2025-02-01T00:00:00.000Z',
+        status: 'ACCEPTED',
+        ProjectSkillTag: [],
+        ProjectPositionTag: [],
+      },
+    ],
+  })
+  acceptedProjects: ProjectResponseDto[];
+
+  @ApiProperty({
+    description: '사용자가 기획한 프로젝트 목록',
+    type: [ProjectResponseDto],
+    example: [
+      {
+        projectId: 2,
+        title: '기획한 프로젝트',
+        description: '기획한 프로젝트 설명',
+        totalMember: 3,
+        startDate: '2025-03-01T00:00:00.000Z',
+        estimatedPeriod: '6개월',
+        methodId: 2,
+        isBeginner: false,
+        isDone: true,
+        recruitmentStartDate: '2025-02-01T00:00:00.000Z',
+        recruitmentEndDate: '2025-04-01T00:00:00.000Z',
+        ProjectSkillTag: [],
+        ProjectPositionTag: [],
+      },
+    ],
+  })
+  ownProjects: ProjectResponseDto[];
+}

--- a/src/modules/user/dto/user-projects-response.dto.ts
+++ b/src/modules/user/dto/user-projects-response.dto.ts
@@ -15,7 +15,7 @@ export class UserProjectsResponseDto {
         estimatedPeriod: '3개월',
         methodId: 1,
         isBeginner: true,
-        isDone: false,
+        isDone: true,
         recruitmentStartDate: '2025-01-01T00:00:00.000Z',
         recruitmentEndDate: '2025-02-01T00:00:00.000Z',
         status: 'ACCEPTED',

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -34,6 +34,7 @@ import { MyInfoResponseDto } from './dto/my-info-response.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { GetAcceptedProjectsDto } from './dto/get-accepted-projects.dto';
 import { ProjectResponseDto } from './dto/project-response.dto';
+import { UserProjectsResponseDto } from './dto/user-projects-response.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -422,14 +423,14 @@ export class UserController {
   @Get(':id/project')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
-    summary: '참여 프로젝트 조회 (특정 사용자)',
+    summary: '참여 및 기획 프로젝트 조회 (특정 사용자)',
     description:
-      '특정 사용자가 참여한 프로젝트 목록을 반환합니다. 경로 파라미터로 사용자 ID를 전달해야 하며, "합격된" 프로젝트만 포함됩니다.',
+      '특정 사용자가 참여한 프로젝트(합격)와 기획한 프로젝트를 반환합니다.',
   })
   @ApiResponse({
     status: 200,
-    description: '특정 사용자가 참여한 프로젝트 목록',
-    type: [ProjectResponseDto],
+    description: '특정 사용자가 참여한 및 기획한 프로젝트 목록',
+    type: UserProjectsResponseDto,
   })
   @ApiResponse({
     status: 400,
@@ -466,8 +467,10 @@ export class UserController {
   })
   @ApiBearerAuth('JWT')
   @UseGuards(JwtAuthGuard)
-  async getManyUserAcceptedProjects(@Param() params: GetAcceptedProjectsDto) {
+  async getManyUserAcceptedProjects(
+    @Param() params: GetAcceptedProjectsDto
+  ): Promise<UserProjectsResponseDto> {
     const { userId } = params;
-    return await this.userService.fetchManyAcceptedProjects(userId);
+    return await this.userService.fetchManyUserProjectsWithOwn(userId);
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -353,10 +353,7 @@ export class UserService {
   
     // 사용자가 기획한 프로젝트 조회
     const ownProjects = await this.prisma.project.findMany({
-      where: { 
-        authorId: userId,
-        isDone: true,  // 완료된 프로젝트만
-      },
+      where: { authorId: userId },
       include: {
         ProjectSkillTag: { include: { SkillTag: true } },
         ProjectPositionTag: { include: { PositionTag: true } },

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -275,6 +275,9 @@ export class UserService {
       where: {
         userId,
         status: 'ACCEPTED', // 필터링
+        Project: {
+          isDone: true, // 완료된 프로젝트만 가져오기
+        },
       },
       include: {
         Project: {
@@ -329,11 +332,14 @@ export class UserService {
   }
 
   async fetchManyUserProjectsWithOwn(userId: number): Promise<UserProjectsResponseDto> {
-    // 참여한 프로젝트 (합격된 프로젝트만 조회)
+    // 참여한 프로젝트 (합격된 프로젝트만 + 완료된 프로젝트만)
     const acceptedProjects = await this.prisma.applicant.findMany({
       where: {
         userId,
         status: 'ACCEPTED',
+        Project: {
+          isDone: true, // 완료된 프로젝트만 가져오기
+        },
       },
       include: {
         Project: {
@@ -347,7 +353,10 @@ export class UserService {
   
     // 사용자가 기획한 프로젝트 조회
     const ownProjects = await this.prisma.project.findMany({
-      where: { authorId: userId },
+      where: { 
+        authorId: userId,
+        isDone: true,  // 완료된 프로젝트만
+      },
       include: {
         ProjectSkillTag: { include: { SkillTag: true } },
         ProjectPositionTag: { include: { PositionTag: true } },


### PR DESCRIPTION
# 🚀 구현한 내용 (What was implemented)

<!-- 구현한 기능이나 변경 사항을 간략히 요약해주세요. -->
- ✨ 주요 기능:
  - [x] 특정 사용자의 참여 및 기획한 프로젝트 조회 서비스 로직 추가
    - acceptedProjects와 ownProjects 배열로 각각 출력.
  - [x] 참여한 프로젝트(acceptedProjects) : 모집 완료된 프로젝트만 조회할 수 있도록 수정 
  - [x] 기획한 프로젝트(ownProjects ):  모집 중과 마감 전부 조회할 수 있도록 수정 
  - [x] 프로젝트 조회 시 `status` 필드를 선택 필수값이 아니도록 변경
  - [x] DTO에 특정 사용자 참여 및 기획 프로젝트 조회 항목 추가
  - [x] 회원가입 시 닉네임 중복 체크 기능 추가

---

# 🖼️ 결과 이미지 (Screenshots)

<!-- 변경된 결과를 확인할 수 있는 스크린샷을 첨부해주세요. -->
 | **특정 사용자의 참여 및 기획한 프로젝트 조회**         |
|-----------------------------|
| ![image](https://github.com/user-attachments/assets/be888ff4-8ff4-42b4-907b-986fbe86342b)     |

---

# 🛠️ 추가 수정 필요 사항 (Additional fixes required)

<!-- PR에 포함되지 않았지만, 추가적으로 해야 할 작업이 있다면 작성해주세요. -->

필요시 수정하겠습니당!

---

# 📝 참고 사항 (Additional notes)

<!-- 테스트 방법, 관련 이슈, 참고 문서 등을 작성해주세요. -->

- **테스트 방법**:
  1. `/users/:id/project` API 호출하여 특정 사용자의 참여 및 기획 프로젝트 조회 테스트!
  2. 회원가입 테스트를 통해 닉네임 중복 확인!